### PR TITLE
Fix default config value to prevent admins API calls via 'x-forwarded-for: 127.0.0.1' header usage

### DIFF
--- a/config.json
+++ b/config.json
@@ -139,7 +139,7 @@
         "sslCert": "./cert.pem",
         "sslKey": "./privkey.pem",
         "sslCA": "./chain.pem",
-        "trustProxyIP": true
+        "trustProxyIP": false
     },
 
     "daemon": {


### PR DESCRIPTION
The problem is that the pool backend can not validate external requests by default if you use  'x-forwarded-for: 127.0.0.1' header. Here is an example (a real data has been obfuscated here):
```
root@somehost:~# curl -X GET   http://example.host:8117/admin_stats   -H 'Cache-Control: no-cache'   -H 'x-forwarded-for: 127.0.0.1'
{"totalOwed":99999,"totalPaid":99999,"totalRevenue":99999,"totalDiff":99999,"totalShares":99999,"blocksOrphaned":99999,"blocksUnlocked":99999,"totalWorkers":99999}
root@somehost:~#
```
According the implementation, I found the problem in the `authorize(request, response) {}` function:
https://github.com/X-CASH-official/cryptonote-nodejs-pool/blob/master/lib/api.js#L1304
if in your config the variable config.api.trustProxyIP is TRUE I can easily add the x-forwarded-for: 127.0.0.1 header to request and then the password on the following lines will be undefined and the following condition will be true, so I'll be authorized successfully for a whole API for the pool's backend:
https://github.com/X-CASH-official/cryptonote-nodejs-pool/blob/master/lib/api.js#L1309:
```
if (typeof sentPass == "undefined" && (remoteAddress === '127.0.0.1' || remoteAddress === '::ffff:127.0.0.1' || remoteAddress === '::1' || (bindIp != "0.0.0.0" && remoteAddress === bindIp))) {
        return true;
    }
```
Fix: just change `config.api.trustProxyIP` default value from TRUE to FALSE and be attentive for the variable usage.